### PR TITLE
Disable cgo to build static binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
       - darwin
       - windows
       - linux
+    env:
+      - CGO_ENABLED=0
     dir: ./provider
     main: ./cmd/pulumi-resource-honeycomb
     binary: pulumi-resource-honeycomb


### PR DESCRIPTION
This fixes an issue where a dynamic linker can't be found if the linux
distribution on which you run pulumi is sufficiently dissimilar from
the build host.