### PR TITLE
Fix generation of the versioned download URL

### DIFF
--- a/provider/cmd/pulumi-resource-honeycomb/schema.json
+++ b/provider/cmd/pulumi-resource-honeycomb/schema.json
@@ -16,7 +16,7 @@
     "attribution": "This Pulumi package is based on the [`honeycombio` Terraform Provider](https://github.com/honeycombio/terraform-provider-honeycombio).",
     "repository": "https://github.com/honeycombio/terraform-provider-honeycombio",
     "logoUrl": "https://raw.githubusercontent.com/MaterializeInc/pulumi-honeycomb/main/assets/honeycomb.svg",
-    "pluginDownloadURL": "https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v${VERSION}",
+    "pluginDownloadURL": "github://api.github.com/MaterializeInc/pulumi-honeycomb",
     "publisher": "Materialize Inc",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -50,7 +50,7 @@ func Provider() tfbridge.ProviderInfo {
 		GitHubOrg:         "honeycombio",
 		Homepage:          "https://github.com/honeycombio/terraform-provider-honeycombio",
 		Repository:        "https://github.com/honeycombio/terraform-provider-honeycombio",
-		PluginDownloadURL: fmt.Sprintf("https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v%s", version.Version),
+		PluginDownloadURL: "github://api.github.com/MaterializeInc/pulumi-honeycomb",
 		DisplayName:       "Honeycomb.io",
 		Config:            map[string]*tfbridge.SchemaInfo{},
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -50,7 +50,7 @@ func Provider() tfbridge.ProviderInfo {
 		GitHubOrg:         "honeycombio",
 		Homepage:          "https://github.com/honeycombio/terraform-provider-honeycombio",
 		Repository:        "https://github.com/honeycombio/terraform-provider-honeycombio",
-		PluginDownloadURL: "https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v${VERSION}",
+		PluginDownloadURL: fmt.Sprintf("https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v%s", version.Version),
 		DisplayName:       "Honeycomb.io",
 		Config:            map[string]*tfbridge.SchemaInfo{},
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/sdk/go/honeycomb/pulumi-plugin.json
+++ b/sdk/go/honeycomb/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "honeycomb",
-  "server": "https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v${VERSION}"
+  "server": "github://api.github.com/MaterializeInc/pulumi-honeycomb"
 }

--- a/sdk/go/honeycomb/pulumiUtilities.go
+++ b/sdk/go/honeycomb/pulumiUtilities.go
@@ -88,14 +88,14 @@ func isZero(v interface{}) bool {
 
 // pkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func pkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
-	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v${VERSION}")}
+	defaults := []pulumi.ResourceOption{pulumi.PluginDownloadURL("github://api.github.com/MaterializeInc/pulumi-honeycomb")}
 
 	return append(defaults, opts...)
 }
 
 // pkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func pkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
-	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("https://github.com/MaterializeInc/pulumi-honeycomb/releases/download/v${VERSION}")}
+	defaults := []pulumi.InvokeOption{pulumi.PluginDownloadURL("github://api.github.com/MaterializeInc/pulumi-honeycomb")}
 
 	return append(defaults, opts...)
 }


### PR DESCRIPTION
It seems that the version interpolation doesn't work properly in newer
versions of the pulumi python library. Let's un-interpolate the version
instead.